### PR TITLE
Add grid size parameters and grid generator for addPanels

### DIFF
--- a/examples/jvm_compiled.json
+++ b/examples/jvm_compiled.json
@@ -105,6 +105,10 @@
       {
          "collapse": false,
          "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24
+         },
          "height": "125px",
          "panels": [
             {
@@ -431,6 +435,10 @@
       {
          "collapse": false,
          "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24
+         },
          "height": "250px",
          "panels": [
             {
@@ -645,6 +653,10 @@
       {
          "collapse": false,
          "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24
+         },
          "height": "250px",
          "panels": [
             {
@@ -760,6 +772,10 @@
       {
          "collapse": false,
          "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24
+         },
          "height": "250px",
          "panels": [
             {
@@ -944,6 +960,10 @@
       {
          "collapse": false,
          "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24
+         },
          "height": "250px",
          "panels": [
             {

--- a/examples/k8s_cluster_summary_compiled.json
+++ b/examples/k8s_cluster_summary_compiled.json
@@ -16,6 +16,10 @@
       {
          "collapse": false,
          "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24
+         },
          "panels": [
             {
                "cacheTimeout": null,
@@ -366,6 +370,10 @@
       {
          "collapse": true,
          "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24
+         },
          "panels": [
             {
                "cacheTimeout": null,
@@ -1060,6 +1068,10 @@
       {
          "collapse": true,
          "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24
+         },
          "panels": [
             {
                "cacheTimeout": null,
@@ -1332,6 +1344,10 @@
       {
          "collapse": true,
          "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24
+         },
          "panels": [
             {
                "cacheTimeout": null,
@@ -1735,6 +1751,10 @@
       {
          "collapse": true,
          "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24
+         },
          "panels": [
             {
                "cacheTimeout": null,

--- a/grafonnet/gauge_panel.libsonnet
+++ b/grafonnet/gauge_panel.libsonnet
@@ -6,6 +6,8 @@
    *
    * @param title Panel title.
    * @param description (optional) Panel description.
+   * @param gridHeight (optional) Height of the panel in Grafana grid units.
+   * @param gridWidth (optional) Width of the panel in Grafana grid units (max: 24).
    * @param transparent (default `false`) Whether to display the panel without a background.
    * @param datasource (optional) Panel datasource.
    * @param allValues (default `false`) Show all values instead of reducing to one.
@@ -40,6 +42,8 @@
   new(
     title,
     description=null,
+    gridHeight=null,
+    gridWidth=null,
     transparent=false,
     datasource=null,
     allValues=false,
@@ -68,6 +72,10 @@
     datasource: datasource,
     targets: [],
     links: [],
+    [if (gridHeight != null || gridWidth != null) then 'gridPos']: {
+      h: gridHeight,
+      w: gridWidth,
+    },
     [if repeat != null then 'repeat']: repeat,
     [if repeat != null then 'repeatDirection']: repeatDirection,
     [if repeat != null then 'repeatMaxPerRow']: repeatMaxPerRow,

--- a/grafonnet/grafana.libsonnet
+++ b/grafonnet/grafana.libsonnet
@@ -27,4 +27,5 @@
   gaugePanel:: import 'gauge_panel.libsonnet',
   barGaugePanel:: import 'bar_gauge_panel.libsonnet',
   statPanel:: import 'stat_panel.libsonnet',
+  utils:: import 'utils.libsonnet',
 }

--- a/grafonnet/graph_panel.libsonnet
+++ b/grafonnet/graph_panel.libsonnet
@@ -8,6 +8,8 @@
    * @param title The title of the graph panel.
    * @param description (optional) The description of the panel
    * @param span (optional) Width of the panel
+   * @param gridHeight (optional) Height of the panel in Grafana grid units
+   * @param gridWidth (optional) Width of the panel in Grafana grid units (max: 24)
    * @param datasource (optional) Datasource
    * @param fill (default `1`) , integer from 0 to 10
    * @param linewidth (default `1`) Line Width, integer from 0 to 10
@@ -93,6 +95,8 @@
     bars=false,
     staircase=false,
     height=null,
+    gridHeight=null,
+    gridWidth=null,
     nullPointMode='null',
     dashes=false,
     stack=false,
@@ -207,6 +211,10 @@
     seriesOverrides: [],
     thresholds: thresholds,
     links: links,
+    [if (gridHeight != null || gridWidth != null) then 'gridPos']: {
+      h: gridHeight,
+      w: gridWidth,
+    },
     yaxe(
       format='short',
       min=null,

--- a/grafonnet/heatmap_panel.libsonnet
+++ b/grafonnet/heatmap_panel.libsonnet
@@ -20,6 +20,8 @@
    * @param color_min (optional) The value for the beginning of the color range
    * @param color_mode (default `'spectrum'`) How to display difference in frequency with color
    * @param dataFormat (default `'timeseries'`) How to format the data
+   * @param gridHeight (optional) Height of the panel in Grafana grid units
+   * @param gridWidth (optional) Width of the panel in Grafana grid units (max: 24)
    * @param highlightCards (default `true`) TODO: document
    * @param hideZeroBuckets (default `false`) Whether or not to hide empty buckets, default is false
    * @param legend_show (default `false`) Show legend
@@ -60,6 +62,8 @@
     color_min=null,
     color_mode='spectrum',
     dataFormat='timeseries',
+    gridHeight=null,
+    gridWidth=null,
     highlightCards=true,
     hideZeroBuckets=false,
     legend_show=false,
@@ -135,6 +139,10 @@
     yBucketBound: yBucketBound,
     [if dataFormat == 'timeseries' then 'yBucketNumber']: yBucketNumber,
     [if dataFormat == 'timeseries' then 'yBucketSize']: yBucketSize,
+    [if (gridHeight != null || gridWidth != null) then 'gridPos']: {
+      h: gridHeight,
+      w: gridWidth,
+    },
 
     _nextTarget:: 0,
     addTarget(target):: self {

--- a/grafonnet/log_panel.libsonnet
+++ b/grafonnet/log_panel.libsonnet
@@ -7,6 +7,8 @@
    *
    * @param title (default `''`) The title of the log panel.
    * @param span (optional) Width of the panel
+   * @param gridHeight (optional) Height of the panel in Grafana grid units
+   * @param gridWidth (optional) Width of the panel in Grafana grid units (max: 24)
    * @param datasource (optional) Datasource
    * @showLabels (default `false`) Whether to show or hide labels
    * @showTime (default `true`) Whether to show or hide time for each line
@@ -27,6 +29,8 @@
     wrapLogMessage=true,
     span=12,
     height=null,
+    gridHeight=null,
+    gridWidth=null,
   ):: {
     [if height != null then 'height']: height,
     span: span,
@@ -52,5 +56,9 @@
     timeShift: time_shift,
     title: title,
     type: 'logs',
+    [if (gridHeight != null || gridWidth != null) then 'gridPos']: {
+      h: gridHeight,
+      w: gridWidth,
+    },
   },
 }

--- a/grafonnet/pie_chart_panel.libsonnet
+++ b/grafonnet/pie_chart_panel.libsonnet
@@ -10,6 +10,8 @@
    * @param description (default `''`) Description of the panel
    * @param span (optional) Width of the panel
    * @param min_span (optional) Min span
+   * @param gridHeight (optional) Height of the panel in Grafana grid units
+   * @param gridWidth (optional) Width of the panel in Grafana grid units (max: 24)
    * @param datasource (optional) Datasource
    * @param aliasColors (optional) Define color mappings
    * @param pieType (default `'pie'`) Type of pie chart (one of pie or donut)
@@ -31,6 +33,8 @@
     min_span=null,
     datasource=null,
     height=null,
+    gridHeight=null,
+    gridWidth=null,
     aliasColors={},
     pieType='pie',
     valueName='current',
@@ -62,6 +66,10 @@
     legendType: legendType,
     targets: [
     ],
+    [if (gridHeight != null || gridWidth != null) then 'gridPos']: {
+      h: gridHeight,
+      w: gridWidth,
+    },
     _nextTarget:: 0,
     addTarget(target):: self {
       local nextTarget = super._nextTarget,

--- a/grafonnet/pluginlist.libsonnet
+++ b/grafonnet/pluginlist.libsonnet
@@ -7,6 +7,8 @@
    *
    * @param title The title of the pluginlist panel.
    * @param description (optional) Description of the panel
+   * @param gridHeight (optional) Height of the panel in Grafana grid units
+   * @param gridWidth (optional) Width of the panel in Grafana grid units (max: 24)
    * @param limit (optional) Set maximum items in a list
    * @return A json that represents a pluginlist panel
    */
@@ -14,10 +16,16 @@
     title,
     description=null,
     limit=null,
+    gridHeight=null,
+    gridWidth=null,
   ):: {
     type: 'pluginlist',
     title: title,
     [if limit != null then 'limit']: limit,
     [if description != null then 'description']: description,
+    [if (gridHeight != null || gridWidth != null) then 'gridPos']: {
+      h: gridHeight,
+      w: gridWidth,
+    },
   },
 }

--- a/grafonnet/row.libsonnet
+++ b/grafonnet/row.libsonnet
@@ -8,6 +8,8 @@
    * @param title The title of the row.
    * @param showTitle (default `true` if title is set) Whether to show the row title
    * @paral titleSize (default `'h6'`) The size of the title
+   * @param gridHeight (optional) Height of the panel in Grafana grid units
+   * @param gridWidth (optional) Width of the panel in Grafana grid units (max: 24)
    * @param collapse (default `false`) The initial state of the row when opening the dashboard. Panels in a collapsed row are not load until the row is expanded.
    * @param repeat (optional) Name of variable that should be used to repeat this row. It is recommended to use the variable in the row title as well.
    *
@@ -17,6 +19,8 @@
   new(
     title='Dashboard Row',
     height=null,
+    gridHeight=1,
+    gridWidth=24,
     collapse=false,
     repeat=null,
     showTitle=null,
@@ -37,6 +41,10 @@
     title: title,
     type: 'row',
     titleSize: titleSize,
+    [if (gridHeight != null || gridWidth != null) then 'gridPos']: {
+      h: gridHeight,
+      w: gridWidth,
+    },
     addPanels(panels):: self {
       panels+: panels,
     },

--- a/grafonnet/singlestat.libsonnet
+++ b/grafonnet/singlestat.libsonnet
@@ -12,6 +12,8 @@
    * @param datasource (optional)
    * @param span (optional)
    * @param min_span (optional)
+   * @param gridHeight (optional) Height of the panel in Grafana grid units
+   * @param gridWidth (optional) Width of the panel in Grafana grid units (max: 24)
    * @param decimals (optional)
    * @param valueName (default `'avg'`)
    * @param valueFontSize (default `'80%'`)
@@ -51,6 +53,8 @@
     description='',
     interval=null,
     height=null,
+    gridHeight=null,
+    gridWidth=null,
     datasource=null,
     span=null,
     min_span=null,
@@ -169,6 +173,10 @@
         show: sparklineShow,
       },
       tableColumn: tableColumn,
+      [if (gridHeight != null || gridWidth != null) then 'gridPos']: {
+        h: gridHeight,
+        w: gridWidth,
+      },
       _nextTarget:: 0,
       addTarget(target):: self {
         local nextTarget = super._nextTarget,

--- a/grafonnet/stat_panel.libsonnet
+++ b/grafonnet/stat_panel.libsonnet
@@ -6,6 +6,8 @@
    *
    * @param title Panel title.
    * @param description (optional) Panel description.
+   * @param gridHeight (optional) Height of the panel in Grafana grid units.
+   * @param gridWidth (optional) Width of the panel in Grafana grid units (max: 24).
    * @param transparent (default `false`) Whether to display the panel without a background.
    * @param datasource (optional) Panel datasource.
    * @param allValues (default `false`) Show all values instead of reducing to one.
@@ -42,6 +44,8 @@
   new(
     title,
     description=null,
+    gridHeight=null,
+    gridWidth=null,
     transparent=false,
     datasource=null,
     allValues=false,
@@ -72,6 +76,10 @@
     datasource: datasource,
     targets: [],
     links: [],
+    [if (gridHeight != null || gridWidth != null) then 'gridPos']: {
+      h: gridHeight,
+      w: gridWidth,
+    },
     [if repeat != null then 'repeat']: repeat,
     [if repeat != null then 'repeatDirection']: repeatDirection,
     [if repeat != null then 'repeatMaxPerRow']: repeatMaxPerRow,

--- a/grafonnet/table_panel.libsonnet
+++ b/grafonnet/table_panel.libsonnet
@@ -9,6 +9,8 @@
    * @param description (optional) Description of the panel
    * @param span (optional)  Width of the panel
    * @param height (optional)  Height of the panel
+   * @param gridHeight (optional) Height of the panel in Grafana grid units
+   * @param gridWidth (optional) Width of the panel in Grafana grid units (max: 24)
    * @param datasource (optional) Datasource
    * @param min_span (optional)  Min span
    * @param styles (optional) Array of styles for the panel
@@ -31,6 +33,8 @@
     span=null,
     min_span=null,
     height=null,
+    gridHeight=null,
+    gridWidth=null,
     datasource=null,
     styles=[],
     transform=null,
@@ -58,6 +62,10 @@
     [if description != null then 'description']: description,
     [if transform != null then 'transform']: transform,
     [if transparent == true then 'transparent']: transparent,
+    [if (gridHeight != null || gridWidth != null) then 'gridPos']: {
+      h: gridHeight,
+      w: gridWidth,
+    },
     _nextTarget:: 0,
     addTarget(target):: self {
       local nextTarget = super._nextTarget,

--- a/grafonnet/text.libsonnet
+++ b/grafonnet/text.libsonnet
@@ -8,6 +8,8 @@
    * @param description (optional) Panel description.
    * @param datasource (optional) Panel datasource.
    * @param span (optional)
+   * @param gridHeight (optional) Height of the panel in Grafana grid units
+   * @param gridWidth (optional) Width of the panel in Grafana grid units (max: 24)
    * @param content (default `''`)
    * @param mode (default `'markdown'`) Rendering of the content: 'markdown','html', ...
    * @param transparent (optional) Whether to display the panel without a background.
@@ -18,6 +20,8 @@
   new(
     title='',
     span=null,
+    gridHeight=null,
+    gridWidth=null,
     mode='markdown',
     content='',
     transparent=null,
@@ -39,5 +43,9 @@
       [if repeat != null then 'repeat']: repeat,
       [if repeat != null then 'repeatDirection']: repeatDirection,
       [if repeat != null then 'maxPerRow']: repeatMaxPerRow,
+      [if (gridHeight != null || gridWidth != null) then 'gridPos']: {
+        h: gridHeight,
+        w: gridWidth,
+      },
     },
 }

--- a/grafonnet/utils.libsonnet
+++ b/grafonnet/utils.libsonnet
@@ -1,0 +1,78 @@
+local grid_width = 24;
+
+{
+  /**
+   * @name utils.generateGrid
+   *
+   * Generate Grafana grid, based on panels size.
+   * Should be called only once with the list of all panels that will be added.
+   * It puts panels from left to right, until there is a free space, and then uses new line.
+   * Line step on a new line break is the height of the last panel in a previous line.
+   * You can use rows as line breaks.
+   * If there are conflicts in grid, Grafana will solve them on import.
+   * Grafana's negative gravity will also be applied on import, it is not computed here.
+   * You should be careful with using both this and dynamic repeating with variables:
+   * static generator do not know about dynamic repeating,
+   * so Grafana conflict solver will be applied on import.
+   *
+   * @param panels List of panels (their sizes must be set)
+   *
+   * @return List of panels with computed grid positions
+   */
+  generateGrid(panels):: [
+    el {
+      gridPos: {
+        x: el.gridPos.x,
+        y: el.gridPos.y,
+        h: el.gridPos.h,
+        w: el.gridPos.w,
+      },
+    }
+    for el in std.foldl(function(_panels, p) (
+      local i = std.length(_panels);
+      local prev = (if i == 0 then null else _panels[i - 1]);
+
+      if i == 0 then
+        _panels + [p { gridPos: {
+          x: 0,
+          y: 0,
+          h: p.gridPos.h,
+          w: p.gridPos.w,
+          x_cursor: p.gridPos.w,
+          y_cursor: 0,
+        } }]
+      else
+        local line_break = prev.gridPos.x_cursor + p.gridPos.w > grid_width;
+        _panels + [p { gridPos: {
+          x:
+            if line_break then
+              0
+            else
+              prev.gridPos.x_cursor,
+
+          y:
+            if line_break then
+              prev.gridPos.y_cursor + prev.gridPos.h
+            else
+              prev.gridPos.y_cursor,
+
+          h: p.gridPos.h,
+
+          w: p.gridPos.w,
+
+          x_cursor:
+            if line_break then
+              p.gridPos.w
+            else
+              prev.gridPos.x_cursor + p.gridPos.w,
+
+          y_cursor:
+            if line_break then
+              prev.gridPos.y_cursor + prev.gridPos.h
+            else
+              prev.gridPos.y_cursor,
+        } }]
+    ), panels, [])
+  ],
+
+}

--- a/tests/dashboards/adds_compiled.json
+++ b/tests/dashboards/adds_compiled.json
@@ -24,6 +24,10 @@
          {
             "collapse": false,
             "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24
+            },
             "height": "250px",
             "panels": [ ],
             "repeat": null,
@@ -37,6 +41,10 @@
          {
             "collapse": false,
             "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24
+            },
             "height": "250px",
             "panels": [ ],
             "repeat": null,
@@ -50,6 +58,10 @@
          {
             "collapse": false,
             "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24
+            },
             "height": "250px",
             "panels": [ ],
             "repeat": null,
@@ -63,6 +75,10 @@
          {
             "collapse": false,
             "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24
+            },
             "height": "250px",
             "panels": [ ],
             "repeat": null,
@@ -215,6 +231,10 @@
          {
             "collapse": false,
             "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24
+            },
             "h": 41,
             "id": 6,
             "panels": [ ],
@@ -418,6 +438,10 @@
          {
             "collapse": false,
             "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24
+            },
             "height": "250px",
             "id": 2,
             "panels": [
@@ -441,6 +465,10 @@
          {
             "collapse": false,
             "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24
+            },
             "height": "250px",
             "id": 5,
             "panels": [ ],
@@ -455,6 +483,10 @@
          {
             "collapse": false,
             "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24
+            },
             "height": "250px",
             "id": 6,
             "panels": [ ],
@@ -485,6 +517,10 @@
          {
             "collapse": false,
             "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24
+            },
             "height": "250px",
             "id": 11,
             "panels": [
@@ -520,6 +556,10 @@
          {
             "collapse": false,
             "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24
+            },
             "id": 17,
             "panels": [
                {
@@ -542,6 +582,10 @@
          {
             "collapse": false,
             "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24
+            },
             "id": 20,
             "panels": [ ],
             "repeat": null,
@@ -555,6 +599,10 @@
          {
             "collapse": false,
             "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24
+            },
             "id": 21,
             "panels": [ ],
             "repeat": null,

--- a/tests/row/test_compiled.json
+++ b/tests/row/test_compiled.json
@@ -2,6 +2,10 @@
    "advanced": {
       "collapse": true,
       "collapsed": true,
+      "gridPos": {
+         "h": 1,
+         "w": 24
+      },
       "height": "125px",
       "panels": [ ],
       "repeat": "env",
@@ -15,6 +19,10 @@
    "basic": {
       "collapse": false,
       "collapsed": false,
+      "gridPos": {
+         "h": 1,
+         "w": 24
+      },
       "panels": [ ],
       "repeat": null,
       "repeatIteration": null,
@@ -27,6 +35,10 @@
    "panels": {
       "collapse": false,
       "collapsed": false,
+      "gridPos": {
+         "h": 1,
+         "w": 24
+      },
       "height": "250px",
       "panels": [
          "foo{\"gridPos\": { }}",
@@ -43,6 +55,10 @@
    "showTite": {
       "collapse": false,
       "collapsed": false,
+      "gridPos": {
+         "h": 1,
+         "w": 24
+      },
       "panels": [ ],
       "repeat": null,
       "repeatIteration": null,

--- a/tests/utils/generateGrid.jsonnet
+++ b/tests/utils/generateGrid.jsonnet
@@ -1,0 +1,62 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local row = grafana.row;
+local graphPanel = grafana.graphPanel;
+local logPanel = grafana.logPanel;
+local tablePanel = grafana.tablePanel;
+local singlestat = grafana.singlestat;
+local pieChartPanel = grafana.pieChartPanel;
+local heatmapPanel = grafana.heatmapPanel;
+local gaugePanel = grafana.gaugePanel;
+local statPanel = grafana.statPanel;
+local utils = grafana.utils;
+
+{
+  basic: dashboard.new('basic').addPanels(
+    utils.generateGrid([
+      graphPanel.new('graph 1', gridHeight=8, gridWidth=12),
+      graphPanel.new('graph 2', gridHeight=8, gridWidth=12),
+    ])
+  ),
+  advanced: dashboard.new('advanced').addPanels(
+    utils.generateGrid([
+      graphPanel.new('graph 1', gridHeight=8, gridWidth=12),
+      graphPanel.new('graph 2', gridHeight=8, gridWidth=12),
+      row.new('row 1'),
+      logPanel.new('log panel', gridHeight=4, gridWidth=10),
+      pieChartPanel.new('pie chart', gridHeight=4, gridWidth=4),
+      gaugePanel.new('gauge', gridHeight=4, gridWidth=5),
+      singlestat.new('singlestat', gridHeight=4, gridWidth=5),
+      singlestat.new('another singlestat', gridHeight=4, gridWidth=5),
+      graphPanel.new('graph 3', gridHeight=4, gridWidth=19),
+      row.new('row 2'),
+      heatmapPanel.new('heatmap', gridHeight=10, gridWidth=10),
+      tablePanel.new('table', gridHeight=10, gridWidth=10),
+      row.new('row 3'),
+      graphPanel.new('graph 4', gridHeight=6, gridWidth=12),
+      statPanel.new('stat', gridHeight=6, gridWidth=6),
+    ])
+  ),
+  repeatExample1: (
+    local servers = ['server1', 'server2', 'server3'];
+    local server_hw_panels = std.flattenArrays([
+      [
+        graphPanel.new('memory', gridHeight=4, gridWidth=10).addTarget({ server: server }),
+        graphPanel.new('ram', gridHeight=4, gridWidth=10).addTarget({ server: server }),
+        gaugePanel.new('cpu', gridHeight=4, gridWidth=4).addTarget({ server: server }),
+      ]
+      for server in servers
+    ]);
+    dashboard.new('repeat example 1').addPanels(utils.generateGrid(server_hw_panels))
+  ),
+  repeatExample2: (
+    local servers = ['server1', 'server2', 'server3'];
+    local server_health_panels = [
+      graphPanel.new('health overview', gridHeight=4, gridWidth=(24 - 5 * std.length(servers))),
+    ] + [
+      tablePanel.new('server instances', gridHeight=4, gridWidth=5).addTarget({ server: server })
+      for server in servers
+    ];
+    dashboard.new('repeat example 2').addPanels(utils.generateGrid(server_health_panels))
+  ),
+}

--- a/tests/utils/generateGrid_compiled.json
+++ b/tests/utils/generateGrid_compiled.json
@@ -1,0 +1,1841 @@
+{
+   "advanced": {
+      "__inputs": [ ],
+      "__requires": [ ],
+      "annotations": {
+         "list": [ ]
+      },
+      "editable": false,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "id": null,
+      "links": [ ],
+      "panels": [
+         {
+            "aliasColors": { },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "gridPos": {
+               "h": 8,
+               "w": 12,
+               "x": 0,
+               "y": 0
+            },
+            "id": 2,
+            "legend": {
+               "alignAsTable": false,
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "rightSide": false,
+               "show": true,
+               "sideWidth": null,
+               "total": false,
+               "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [ ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [ ],
+            "thresholds": [ ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "graph 1",
+            "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": [ ]
+            },
+            "yaxes": [
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               }
+            ]
+         },
+         {
+            "aliasColors": { },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "gridPos": {
+               "h": 8,
+               "w": 12,
+               "x": 12,
+               "y": 0
+            },
+            "id": 3,
+            "legend": {
+               "alignAsTable": false,
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "rightSide": false,
+               "show": true,
+               "sideWidth": null,
+               "total": false,
+               "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [ ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [ ],
+            "thresholds": [ ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "graph 2",
+            "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": [ ]
+            },
+            "yaxes": [
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               }
+            ]
+         },
+         {
+            "collapse": false,
+            "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0,
+               "y": 8
+            },
+            "id": 4,
+            "panels": [ ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "row 1",
+            "titleSize": "h6",
+            "type": "row"
+         },
+         {
+            "datasource": null,
+            "gridPos": {
+               "h": 4,
+               "w": 10,
+               "x": 0,
+               "y": 9
+            },
+            "id": 5,
+            "options": {
+               "showLabels": false,
+               "showTime": true,
+               "sortOrder": "Descending",
+               "wrapLogMessage": true
+            },
+            "span": 12,
+            "targets": [ ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "log panel",
+            "type": "logs"
+         },
+         {
+            "aliasColors": { },
+            "datasource": null,
+            "description": "",
+            "gridPos": {
+               "h": 4,
+               "w": 4,
+               "x": 10,
+               "y": 9
+            },
+            "id": 6,
+            "legend": {
+               "percentage": true,
+               "show": true,
+               "values": true
+            },
+            "legendType": "Right side",
+            "pieType": "pie",
+            "targets": [ ],
+            "title": "pie chart",
+            "type": "grafana-piechart-panel",
+            "valueName": "current"
+         },
+         {
+            "datasource": null,
+            "fieldConfig": {
+               "defaults": {
+                  "links": [ ],
+                  "mappings": [ ],
+                  "max": 100,
+                  "min": 0,
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "percent"
+               }
+            },
+            "gridPos": {
+               "h": 4,
+               "w": 5,
+               "x": 14,
+               "y": 9
+            },
+            "id": 7,
+            "links": [ ],
+            "options": {
+               "reduceOptions": {
+                  "calcs": [
+                     "mean"
+                  ],
+                  "fields": "",
+                  "values": false
+               },
+               "showThresholdLabels": false,
+               "showThresholdMarkers": true
+            },
+            "pluginVersion": "7",
+            "targets": [ ],
+            "title": "gauge",
+            "transparent": false,
+            "type": "gauge"
+         },
+         {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+               "#299c46",
+               "rgba(237, 129, 40, 0.89)",
+               "#d44a3a"
+            ],
+            "datasource": null,
+            "format": "none",
+            "gauge": {
+               "maxValue": 100,
+               "minValue": 0,
+               "show": false,
+               "thresholdLabels": false,
+               "thresholdMarkers": true
+            },
+            "gridPos": {
+               "h": 4,
+               "w": 5,
+               "x": 19,
+               "y": 9
+            },
+            "id": 8,
+            "interval": null,
+            "links": [ ],
+            "mappingType": 1,
+            "mappingTypes": [
+               {
+                  "name": "value to text",
+                  "value": 1
+               },
+               {
+                  "name": "range to text",
+                  "value": 2
+               }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+               {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+               }
+            ],
+            "sparkline": {
+               "fillColor": "rgba(31, 118, 189, 0.18)",
+               "full": false,
+               "lineColor": "rgb(31, 120, 193)",
+               "show": false
+            },
+            "tableColumn": "",
+            "targets": [ ],
+            "thresholds": "",
+            "title": "singlestat",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+               {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+               }
+            ],
+            "valueName": "avg"
+         },
+         {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+               "#299c46",
+               "rgba(237, 129, 40, 0.89)",
+               "#d44a3a"
+            ],
+            "datasource": null,
+            "format": "none",
+            "gauge": {
+               "maxValue": 100,
+               "minValue": 0,
+               "show": false,
+               "thresholdLabels": false,
+               "thresholdMarkers": true
+            },
+            "gridPos": {
+               "h": 4,
+               "w": 5,
+               "x": 0,
+               "y": 13
+            },
+            "id": 9,
+            "interval": null,
+            "links": [ ],
+            "mappingType": 1,
+            "mappingTypes": [
+               {
+                  "name": "value to text",
+                  "value": 1
+               },
+               {
+                  "name": "range to text",
+                  "value": 2
+               }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+               {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+               }
+            ],
+            "sparkline": {
+               "fillColor": "rgba(31, 118, 189, 0.18)",
+               "full": false,
+               "lineColor": "rgb(31, 120, 193)",
+               "show": false
+            },
+            "tableColumn": "",
+            "targets": [ ],
+            "thresholds": "",
+            "title": "another singlestat",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+               {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+               }
+            ],
+            "valueName": "avg"
+         },
+         {
+            "aliasColors": { },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "gridPos": {
+               "h": 4,
+               "w": 19,
+               "x": 5,
+               "y": 13
+            },
+            "id": 10,
+            "legend": {
+               "alignAsTable": false,
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "rightSide": false,
+               "show": true,
+               "sideWidth": null,
+               "total": false,
+               "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [ ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [ ],
+            "thresholds": [ ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "graph 3",
+            "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": [ ]
+            },
+            "yaxes": [
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               }
+            ]
+         },
+         {
+            "collapse": false,
+            "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0,
+               "y": 17
+            },
+            "id": 11,
+            "panels": [ ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "row 2",
+            "titleSize": "h6",
+            "type": "row"
+         },
+         {
+            "cards": {
+               "cardPadding": null,
+               "cardRound": null
+            },
+            "color": {
+               "cardColor": "#b4ff00",
+               "colorScale": "sqrt",
+               "colorScheme": "interpolateOranges",
+               "exponent": 0.5,
+               "mode": "spectrum"
+            },
+            "dataFormat": "timeseries",
+            "datasource": null,
+            "gridPos": {
+               "h": 10,
+               "w": 10,
+               "x": 0,
+               "y": 18
+            },
+            "heatmap": { },
+            "hideZeroBuckets": false,
+            "highlightCards": true,
+            "id": 12,
+            "legend": {
+               "show": false
+            },
+            "title": "heatmap",
+            "tooltip": {
+               "show": true,
+               "showHistogram": false
+            },
+            "type": "heatmap",
+            "xAxis": {
+               "show": true
+            },
+            "xBucketNumber": null,
+            "xBucketSize": null,
+            "yAxis": {
+               "decimals": null,
+               "format": "short",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true,
+               "splitFactor": null
+            },
+            "yBucketBound": "auto",
+            "yBucketNumber": null,
+            "yBucketSize": null
+         },
+         {
+            "columns": [ ],
+            "datasource": null,
+            "gridPos": {
+               "h": 10,
+               "w": 10,
+               "x": 10,
+               "y": 18
+            },
+            "id": 13,
+            "links": [ ],
+            "styles": [ ],
+            "targets": [ ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "table",
+            "type": "table"
+         },
+         {
+            "collapse": false,
+            "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0,
+               "y": 28
+            },
+            "id": 14,
+            "panels": [ ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "row 3",
+            "titleSize": "h6",
+            "type": "row"
+         },
+         {
+            "aliasColors": { },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "gridPos": {
+               "h": 6,
+               "w": 12,
+               "x": 0,
+               "y": 29
+            },
+            "id": 15,
+            "legend": {
+               "alignAsTable": false,
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "rightSide": false,
+               "show": true,
+               "sideWidth": null,
+               "total": false,
+               "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [ ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [ ],
+            "thresholds": [ ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "graph 4",
+            "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": [ ]
+            },
+            "yaxes": [
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               }
+            ]
+         },
+         {
+            "datasource": null,
+            "fieldConfig": {
+               "defaults": {
+                  "links": [ ],
+                  "mappings": [ ],
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "none"
+               }
+            },
+            "gridPos": {
+               "h": 6,
+               "w": 6,
+               "x": 12,
+               "y": 29
+            },
+            "id": 16,
+            "links": [ ],
+            "options": {
+               "colorMode": "value",
+               "graphMode": "area",
+               "justifyMode": "auto",
+               "orientation": "auto",
+               "reduceOptions": {
+                  "calcs": [
+                     "mean"
+                  ],
+                  "fields": "",
+                  "values": false
+               }
+            },
+            "pluginVersion": "7",
+            "targets": [ ],
+            "title": "stat",
+            "transparent": false,
+            "type": "stat"
+         }
+      ],
+      "refresh": "",
+      "rows": [ ],
+      "schemaVersion": 14,
+      "style": "dark",
+      "tags": [ ],
+      "templating": {
+         "list": [ ]
+      },
+      "time": {
+         "from": "now-6h",
+         "to": "now"
+      },
+      "timepicker": {
+         "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+         ],
+         "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+         ]
+      },
+      "timezone": "browser",
+      "title": "advanced",
+      "version": 0
+   },
+   "basic": {
+      "__inputs": [ ],
+      "__requires": [ ],
+      "annotations": {
+         "list": [ ]
+      },
+      "editable": false,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "id": null,
+      "links": [ ],
+      "panels": [
+         {
+            "aliasColors": { },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "gridPos": {
+               "h": 8,
+               "w": 12,
+               "x": 0,
+               "y": 0
+            },
+            "id": 2,
+            "legend": {
+               "alignAsTable": false,
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "rightSide": false,
+               "show": true,
+               "sideWidth": null,
+               "total": false,
+               "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [ ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [ ],
+            "thresholds": [ ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "graph 1",
+            "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": [ ]
+            },
+            "yaxes": [
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               }
+            ]
+         },
+         {
+            "aliasColors": { },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "gridPos": {
+               "h": 8,
+               "w": 12,
+               "x": 12,
+               "y": 0
+            },
+            "id": 3,
+            "legend": {
+               "alignAsTable": false,
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "rightSide": false,
+               "show": true,
+               "sideWidth": null,
+               "total": false,
+               "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [ ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [ ],
+            "thresholds": [ ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "graph 2",
+            "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": [ ]
+            },
+            "yaxes": [
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               }
+            ]
+         }
+      ],
+      "refresh": "",
+      "rows": [ ],
+      "schemaVersion": 14,
+      "style": "dark",
+      "tags": [ ],
+      "templating": {
+         "list": [ ]
+      },
+      "time": {
+         "from": "now-6h",
+         "to": "now"
+      },
+      "timepicker": {
+         "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+         ],
+         "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+         ]
+      },
+      "timezone": "browser",
+      "title": "basic",
+      "version": 0
+   },
+   "repeatExample1": {
+      "__inputs": [ ],
+      "__requires": [ ],
+      "annotations": {
+         "list": [ ]
+      },
+      "editable": false,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "id": null,
+      "links": [ ],
+      "panels": [
+         {
+            "aliasColors": { },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "gridPos": {
+               "h": 4,
+               "w": 10,
+               "x": 0,
+               "y": 0
+            },
+            "id": 2,
+            "legend": {
+               "alignAsTable": false,
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "rightSide": false,
+               "show": true,
+               "sideWidth": null,
+               "total": false,
+               "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [ ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+               {
+                  "refId": "A",
+                  "server": "server1"
+               }
+            ],
+            "thresholds": [ ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "memory",
+            "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": [ ]
+            },
+            "yaxes": [
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               }
+            ]
+         },
+         {
+            "aliasColors": { },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "gridPos": {
+               "h": 4,
+               "w": 10,
+               "x": 10,
+               "y": 0
+            },
+            "id": 3,
+            "legend": {
+               "alignAsTable": false,
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "rightSide": false,
+               "show": true,
+               "sideWidth": null,
+               "total": false,
+               "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [ ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+               {
+                  "refId": "A",
+                  "server": "server1"
+               }
+            ],
+            "thresholds": [ ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "ram",
+            "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": [ ]
+            },
+            "yaxes": [
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               }
+            ]
+         },
+         {
+            "datasource": null,
+            "fieldConfig": {
+               "defaults": {
+                  "links": [ ],
+                  "mappings": [ ],
+                  "max": 100,
+                  "min": 0,
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "percent"
+               }
+            },
+            "gridPos": {
+               "h": 4,
+               "w": 4,
+               "x": 20,
+               "y": 0
+            },
+            "id": 4,
+            "links": [ ],
+            "options": {
+               "reduceOptions": {
+                  "calcs": [
+                     "mean"
+                  ],
+                  "fields": "",
+                  "values": false
+               },
+               "showThresholdLabels": false,
+               "showThresholdMarkers": true
+            },
+            "pluginVersion": "7",
+            "targets": [
+               {
+                  "refId": "A",
+                  "server": "server1"
+               }
+            ],
+            "title": "cpu",
+            "transparent": false,
+            "type": "gauge"
+         },
+         {
+            "aliasColors": { },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "gridPos": {
+               "h": 4,
+               "w": 10,
+               "x": 0,
+               "y": 4
+            },
+            "id": 5,
+            "legend": {
+               "alignAsTable": false,
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "rightSide": false,
+               "show": true,
+               "sideWidth": null,
+               "total": false,
+               "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [ ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+               {
+                  "refId": "A",
+                  "server": "server2"
+               }
+            ],
+            "thresholds": [ ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "memory",
+            "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": [ ]
+            },
+            "yaxes": [
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               }
+            ]
+         },
+         {
+            "aliasColors": { },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "gridPos": {
+               "h": 4,
+               "w": 10,
+               "x": 10,
+               "y": 4
+            },
+            "id": 6,
+            "legend": {
+               "alignAsTable": false,
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "rightSide": false,
+               "show": true,
+               "sideWidth": null,
+               "total": false,
+               "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [ ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+               {
+                  "refId": "A",
+                  "server": "server2"
+               }
+            ],
+            "thresholds": [ ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "ram",
+            "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": [ ]
+            },
+            "yaxes": [
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               }
+            ]
+         },
+         {
+            "datasource": null,
+            "fieldConfig": {
+               "defaults": {
+                  "links": [ ],
+                  "mappings": [ ],
+                  "max": 100,
+                  "min": 0,
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "percent"
+               }
+            },
+            "gridPos": {
+               "h": 4,
+               "w": 4,
+               "x": 20,
+               "y": 4
+            },
+            "id": 7,
+            "links": [ ],
+            "options": {
+               "reduceOptions": {
+                  "calcs": [
+                     "mean"
+                  ],
+                  "fields": "",
+                  "values": false
+               },
+               "showThresholdLabels": false,
+               "showThresholdMarkers": true
+            },
+            "pluginVersion": "7",
+            "targets": [
+               {
+                  "refId": "A",
+                  "server": "server2"
+               }
+            ],
+            "title": "cpu",
+            "transparent": false,
+            "type": "gauge"
+         },
+         {
+            "aliasColors": { },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "gridPos": {
+               "h": 4,
+               "w": 10,
+               "x": 0,
+               "y": 8
+            },
+            "id": 8,
+            "legend": {
+               "alignAsTable": false,
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "rightSide": false,
+               "show": true,
+               "sideWidth": null,
+               "total": false,
+               "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [ ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+               {
+                  "refId": "A",
+                  "server": "server3"
+               }
+            ],
+            "thresholds": [ ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "memory",
+            "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": [ ]
+            },
+            "yaxes": [
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               }
+            ]
+         },
+         {
+            "aliasColors": { },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "gridPos": {
+               "h": 4,
+               "w": 10,
+               "x": 10,
+               "y": 8
+            },
+            "id": 9,
+            "legend": {
+               "alignAsTable": false,
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "rightSide": false,
+               "show": true,
+               "sideWidth": null,
+               "total": false,
+               "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [ ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+               {
+                  "refId": "A",
+                  "server": "server3"
+               }
+            ],
+            "thresholds": [ ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "ram",
+            "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": [ ]
+            },
+            "yaxes": [
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               }
+            ]
+         },
+         {
+            "datasource": null,
+            "fieldConfig": {
+               "defaults": {
+                  "links": [ ],
+                  "mappings": [ ],
+                  "max": 100,
+                  "min": 0,
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "percent"
+               }
+            },
+            "gridPos": {
+               "h": 4,
+               "w": 4,
+               "x": 20,
+               "y": 8
+            },
+            "id": 10,
+            "links": [ ],
+            "options": {
+               "reduceOptions": {
+                  "calcs": [
+                     "mean"
+                  ],
+                  "fields": "",
+                  "values": false
+               },
+               "showThresholdLabels": false,
+               "showThresholdMarkers": true
+            },
+            "pluginVersion": "7",
+            "targets": [
+               {
+                  "refId": "A",
+                  "server": "server3"
+               }
+            ],
+            "title": "cpu",
+            "transparent": false,
+            "type": "gauge"
+         }
+      ],
+      "refresh": "",
+      "rows": [ ],
+      "schemaVersion": 14,
+      "style": "dark",
+      "tags": [ ],
+      "templating": {
+         "list": [ ]
+      },
+      "time": {
+         "from": "now-6h",
+         "to": "now"
+      },
+      "timepicker": {
+         "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+         ],
+         "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+         ]
+      },
+      "timezone": "browser",
+      "title": "repeat example 1",
+      "version": 0
+   },
+   "repeatExample2": {
+      "__inputs": [ ],
+      "__requires": [ ],
+      "annotations": {
+         "list": [ ]
+      },
+      "editable": false,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "id": null,
+      "links": [ ],
+      "panels": [
+         {
+            "aliasColors": { },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "gridPos": {
+               "h": 4,
+               "w": 9,
+               "x": 0,
+               "y": 0
+            },
+            "id": 2,
+            "legend": {
+               "alignAsTable": false,
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "rightSide": false,
+               "show": true,
+               "sideWidth": null,
+               "total": false,
+               "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [ ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [ ],
+            "thresholds": [ ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "health overview",
+            "tooltip": {
+               "shared": true,
+               "sort": 0,
+               "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+               "buckets": null,
+               "mode": "time",
+               "name": null,
+               "show": true,
+               "values": [ ]
+            },
+            "yaxes": [
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               },
+               {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+               }
+            ]
+         },
+         {
+            "columns": [ ],
+            "datasource": null,
+            "gridPos": {
+               "h": 4,
+               "w": 5,
+               "x": 9,
+               "y": 0
+            },
+            "id": 3,
+            "links": [ ],
+            "styles": [ ],
+            "targets": [
+               {
+                  "refId": "A",
+                  "server": "server1"
+               }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "server instances",
+            "type": "table"
+         },
+         {
+            "columns": [ ],
+            "datasource": null,
+            "gridPos": {
+               "h": 4,
+               "w": 5,
+               "x": 14,
+               "y": 0
+            },
+            "id": 4,
+            "links": [ ],
+            "styles": [ ],
+            "targets": [
+               {
+                  "refId": "A",
+                  "server": "server2"
+               }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "server instances",
+            "type": "table"
+         },
+         {
+            "columns": [ ],
+            "datasource": null,
+            "gridPos": {
+               "h": 4,
+               "w": 5,
+               "x": 19,
+               "y": 0
+            },
+            "id": 5,
+            "links": [ ],
+            "styles": [ ],
+            "targets": [
+               {
+                  "refId": "A",
+                  "server": "server3"
+               }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "server instances",
+            "type": "table"
+         }
+      ],
+      "refresh": "",
+      "rows": [ ],
+      "schemaVersion": 14,
+      "style": "dark",
+      "tags": [ ],
+      "templating": {
+         "list": [ ]
+      },
+      "time": {
+         "from": "now-6h",
+         "to": "now"
+      },
+      "timepicker": {
+         "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+         ],
+         "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+         ]
+      },
+      "timezone": "browser",
+      "title": "repeat example 2",
+      "version": 0
+   }
+}


### PR DESCRIPTION
Add grid size ('gridPos = {h: gridHeigth, w: gridWidth}') optional parameters for all panels.
Values are null by default, except for row panel: 'gridPos = {h: 1, w: 24}' by default, like in Grafana.
Instead of explicitly setting position for every panel in addPanel() call,
you can create a list of all panels (their size must be set) and use grid generation utility like this:
'dashboard.new("board").addPanels(utils.generateGrid(panels))'.